### PR TITLE
Created Team_PQ and added blank test files

### DIFF
--- a/backend/internal/pq/priority_queue.go
+++ b/backend/internal/pq/priority_queue.go
@@ -19,9 +19,20 @@ func NewPriorityQueue[T any](less Comparator[T]) *PriorityQueue[T] {
 	return pq
 }
 
+func NewPriorityQueueFromSlice[T any](slice []T, less Comparator[T]) *PriorityQueue[T] {
+	pq := &PriorityQueue[T]{items: slice, less: less}
+	heap.Init(pq)
+	return pq
+}
+
 func (pq *PriorityQueue[T]) Len() int           { return len(pq.items) }
 func (pq *PriorityQueue[T]) Less(i, j int) bool { return pq.less(pq.items[i], pq.items[j]) }
 func (pq *PriorityQueue[T]) Swap(i, j int)      { pq.items[i], pq.items[j] = pq.items[j], pq.items[i] }
+
+// Returns the internal slice of items
+func (pq *PriorityQueue[T]) GetItems() []T {
+	return pq.items
+}
 
 // required -- do not use
 func (pq *PriorityQueue[T]) Push(x any) {

--- a/backend/internal/team/team.go
+++ b/backend/internal/team/team.go
@@ -11,7 +11,9 @@ import (
 // the team will meet at.
 type Team struct {
 	Name        string
-	TeamMembers map[string]player.Player
+	TeamMembers map[string]*player.Player
+	NumMembers  int
+	MaxMembers  int
 	TimeSlot    time.TimeSlot
 }
 
@@ -19,11 +21,18 @@ type Team struct {
 // param: the team name
 // param: the teams timeslot
 // return: a pointer to the new team
-func NewTeam(name string, timeSlot time.TimeSlot) *Team {
+func NewTeam(name string, timeSlot time.TimeSlot, max int) *Team {
 	t := &Team{}
 	t.Name = name
-	t.TeamMembers = make(map[string]player.Player)
+	t.TeamMembers = make(map[string]*player.Player)
+	t.NumMembers = 0
+	t.MaxMembers = max
 	t.TimeSlot = timeSlot
 
 	return t
+}
+
+func (t *Team) AddPlayer(player *player.Player) {
+	t.TeamMembers[player.Id] = player
+	t.NumMembers++
 }

--- a/backend/internal/team/team_pq.go
+++ b/backend/internal/team/team_pq.go
@@ -3,24 +3,35 @@
 package team
 
 import (
+	"github.com/nick-Sutton/Gaggle/backend/internal/player"
 	"github.com/nick-Sutton/Gaggle/backend/internal/pq"
 )
 
 // Dynamic Heap for integers
 type TeamPQ struct {
-	*pq.PriorityQueue[Team]
+	*pq.PriorityQueue[*Team]
 }
 
 // Create a PQ containing teams and defines
 // the PQ's comparison function.
 // When a TeamPQ is is a max heap.
 func NewTeamPQ() *TeamPQ {
-	maxCmp := func(a, b Team) bool {
-		aLen := len(a.TeamMembers)
-		bLen := len(b.TeamMembers)
+	maxCmp := func(a, b *Team) bool {
+		aLen := a.NumMembers
+		bLen := b.NumMembers
+
+		if aLen == a.MaxMembers {
+			return false
+		}
+
+		if bLen == b.MaxMembers {
+			return true
+		}
+
 		if aLen != bLen {
 			return aLen > bLen
 		}
+
 		return true
 	}
 
@@ -29,18 +40,32 @@ func NewTeamPQ() *TeamPQ {
 
 // Rebuilds the a maxheap TeamPQ into a minHeap
 func RebuildPQ(maxTeamPQ *TeamPQ) *TeamPQ {
-	minCmp := func(a, b Team) bool {
-		aLen := len(a.TeamMembers)
-		bLen := len(b.TeamMembers)
+	minCmp := func(a, b *Team) bool {
+		aLen := a.NumMembers
+		bLen := b.NumMembers
 		if aLen != bLen {
 			return aLen < bLen
 		}
 		return true
 	}
 
+	// Consider adding items to new PQ after construction
 	teamSlice := maxTeamPQ.GetItems()
 	minTeamPQ := TeamPQ{pq.NewPriorityQueueFromSlice(teamSlice, minCmp)}
 
 	return &minTeamPQ
 
+}
+
+// Adds a team to the PQ
+func (tpq *TeamPQ) AddTeam(team *Team) {
+	tpq.PriorityQueue.PushItem(team)
+}
+
+// Adds a player to the team at the front of the pq
+func (tpq *TeamPQ) AddToTeam(player *player.Player) *Team {
+	currTeam := tpq.PopItem()
+	currTeam.AddPlayer(player)
+	tpq.PushItem(currTeam)
+	return currTeam
 }

--- a/backend/internal/team/team_pq.go
+++ b/backend/internal/team/team_pq.go
@@ -1,3 +1,46 @@
+// Provides the implementation for a priority queue of teams
+// author: Nicholas Sutton
 package team
 
-// nothing so far
+import (
+	"github.com/nick-Sutton/Gaggle/backend/internal/pq"
+)
+
+// Dynamic Heap for integers
+type TeamPQ struct {
+	*pq.PriorityQueue[Team]
+}
+
+// Create a PQ containing teams and defines
+// the PQ's comparison function.
+// When a TeamPQ is is a max heap.
+func NewTeamPQ() *TeamPQ {
+	maxCmp := func(a, b Team) bool {
+		aLen := len(a.TeamMembers)
+		bLen := len(b.TeamMembers)
+		if aLen != bLen {
+			return aLen > bLen
+		}
+		return true
+	}
+
+	return &TeamPQ{pq.NewPriorityQueue(maxCmp)}
+}
+
+// Rebuilds the a maxheap TeamPQ into a minHeap
+func RebuildPQ(maxTeamPQ *TeamPQ) *TeamPQ {
+	minCmp := func(a, b Team) bool {
+		aLen := len(a.TeamMembers)
+		bLen := len(b.TeamMembers)
+		if aLen != bLen {
+			return aLen < bLen
+		}
+		return true
+	}
+
+	teamSlice := maxTeamPQ.GetItems()
+	minTeamPQ := TeamPQ{pq.NewPriorityQueueFromSlice(teamSlice, minCmp)}
+
+	return &minTeamPQ
+
+}

--- a/backend/test/io/io_test.go
+++ b/backend/test/io/io_test.go
@@ -1,0 +1,1 @@
+package io_test

--- a/backend/test/player/player_pq_test.go
+++ b/backend/test/player/player_pq_test.go
@@ -1,0 +1,1 @@
+package player_test

--- a/backend/test/player/player_pq_test.go
+++ b/backend/test/player/player_pq_test.go
@@ -1,1 +1,8 @@
 package player_test
+
+import (
+	"testing"
+)
+
+func TestNewPlayerPQ(t *testing.T) {
+}

--- a/backend/test/pq_test/priority_queue_test.go
+++ b/backend/test/pq_test/priority_queue_test.go
@@ -1,0 +1,8 @@
+package pqtest_test
+
+import (
+	"testing"
+)
+
+func Test(t *testing.T) {
+}

--- a/backend/test/team/team_pq_test.go
+++ b/backend/test/team/team_pq_test.go
@@ -1,13 +1,112 @@
+// Test cases for TeamPQ
+// author: Nicholas Sutton
 package team_test
 
 import (
 	"testing"
 
+	"github.com/nick-Sutton/Gaggle/backend/internal/player"
 	"github.com/nick-Sutton/Gaggle/backend/internal/team"
+	"github.com/nick-Sutton/Gaggle/backend/internal/time"
 )
 
-func TestNewTeapPQ(t *testing.T) {
-	tpq := team.NewTeamPQ()
+func TestNewTeamPQ(t *testing.T) {
+	team1 := team.NewTeam("team1", *time.NewTimeSlot(time.Monday, time.Slot_4_5pm), 3)
+	team2 := team.NewTeam("team2", *time.NewTimeSlot(time.Tuesday, time.Slot_5_6pm), 3)
+	team3 := team.NewTeam("team3", *time.NewTimeSlot(time.Wednesday, time.Slot_6_7pm), 3)
+	team4 := team.NewTeam("team4", *time.NewTimeSlot(time.Thursday, time.Slot_8_9pm), 3)
+	team5 := team.NewTeam("team5", *time.NewTimeSlot(time.Friday, time.Slot_4_5pm), 3)
 
-	tpq = team.RebuildPQ(tpq)
+	tpq := team.NewTeamPQ()
+	tpq.AddTeam(team1)
+
+	if tpq.Peek() != team1 {
+		t.Errorf("AddTeam result is incorrect, got: %s, expected %s", tpq.Peek().Name, team1.Name)
+	}
+
+	tpq.AddTeam(team2)
+
+	if tpq.Peek() != team2 {
+		t.Errorf("AddTeam result is incorrect, got: %s, expected %s", tpq.Peek().Name, team2.Name)
+	}
+	tpq.AddTeam(team3)
+
+	if tpq.Peek() != team3 {
+		t.Errorf("AddTeam result is incorrect, got: %s, expected %s", tpq.Peek().Name, team3.Name)
+	}
+
+	tpq.AddTeam(team4)
+
+	if tpq.Peek() != team4 {
+		t.Errorf("AddTeam result is incorrect, got: %s, expected %s", tpq.Peek().Name, team4.Name)
+	}
+
+	tpq.AddTeam(team5)
+
+	if tpq.Peek() != team5 {
+		t.Errorf("AddTeam result is incorrect, got: %s, expected %s", tpq.Peek().Name, team5.Name)
+	}
+
+	p1 := player.NewPlayer("playerOneFirst", "playerOneLast", "one@email.com")
+	p2 := player.NewPlayer("playerTwoFirst", "playerTwoLast", "two@email.com")
+	p3 := player.NewPlayer("playerThreeFirst", "playerThreeLast", "three@email.com")
+	p4 := player.NewPlayer("playerFourFirst", "playerFourLast", "four@email.com")
+	p5 := player.NewPlayer("playerFiveFirst", "playerFiveLast", "five@email.com")
+	p6 := player.NewPlayer("playerSixFirst", "playerSixLast", "six@email.com")
+	p7 := player.NewPlayer("playerSevenFirst", "playerSevenLast", "seven@email.com")
+	p8 := player.NewPlayer("playerEightFirst", "playerEightLast", "eight@email.com")
+	p9 := player.NewPlayer("playerNineFirst", "playerNineLast", "nine@email.com")
+	currTeam := tpq.AddToTeam(p1)
+	if currTeam != team5 {
+		t.Errorf("AddPlayer result is incorrect, got: %s, expected %s", currTeam.Name, team5.Name)
+	}
+
+	currTeam = tpq.AddToTeam(p2)
+
+	if currTeam != team5 {
+		t.Errorf("AddPlayer result is incorrect, got: %s, expected %s", currTeam.Name, team5.Name)
+	}
+
+	currTeam = tpq.AddToTeam(p3)
+
+	if currTeam != team5 {
+		t.Errorf("AddPlayer result is incorrect, got: %s, expected %s", currTeam.Name, team5.Name)
+	}
+
+	currTeam = tpq.AddToTeam(p4)
+
+	if currTeam != team4 {
+		t.Errorf("AddPlayer result is incorrect, got: %s, expected %s", currTeam.Name, team4.Name)
+	}
+
+	currTeam = tpq.AddToTeam(p5)
+
+	if currTeam != team4 {
+		t.Errorf("AddPlayer result is incorrect, got: %s, expected %s", currTeam.Name, team4.Name)
+	}
+
+	currTeam = tpq.AddToTeam(p6)
+
+	if currTeam != team4 {
+		t.Errorf("AddPlayer result is incorrect, got: %s, expected %s", currTeam.Name, team4.Name)
+	}
+
+	currTeam = tpq.AddToTeam(p7)
+
+	if currTeam != team3 {
+		t.Errorf("AddPlayer result is incorrect, got: %s, expected %s", currTeam.Name, team3.Name)
+	}
+
+	currTeam = tpq.AddToTeam(p8)
+
+	if currTeam != team3 {
+		t.Errorf("AddPlayer result is incorrect, got: %s, expected %s", currTeam.Name, team3.Name)
+	}
+
+	currTeam = tpq.AddToTeam(p9)
+
+	if currTeam != team3 {
+		t.Errorf("AddPlayer result is incorrect, got: %s, expected %s", currTeam.Name, team3.Name)
+	}
+
 }

--- a/backend/test/team/team_pq_test.go
+++ b/backend/test/team/team_pq_test.go
@@ -1,0 +1,13 @@
+package team_test
+
+import (
+	"testing"
+
+	"github.com/nick-Sutton/Gaggle/backend/internal/team"
+)
+
+func TestNewTeapPQ(t *testing.T) {
+	tpq := team.NewTeamPQ()
+
+	tpq = team.RebuildPQ(tpq)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/nick-Sutton/Gaggle
 go 1.24.2
 
 require (
+	github.com/go-chi/chi/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/twistingmercury/go-figure v0.0.0-20230814213628-6539af590efe
 )
-
-require github.com/go-chi/chi/v5 v5.2.1 // indirect


### PR DESCRIPTION
I had to add two functions to the PQ data structure to support rebuilding the Team priority queue and switching it from a max to a min heap. This was done since iterating through one pq and copying into another is less efficient than getting a copy of its internal slice. Please take a look, and we can discuss if you think my implementation solves our issue correctly.